### PR TITLE
update to work with reosurce-loader 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function (PIXI)
     return function (resource, next)
     {
         // skip if no data, its not json, or it isn't a pixi-packer manifest
-        if (!resource.data || !resource.isJson || !resource.data.meta || resource.data.meta.type !== "pixi-packer") {
+        if (!resource.data || resource.type !== Resource.TYPE.JSON || !resource.data.meta || resource.data.meta.type !== "pixi-packer") {
             return next();
         }
 
@@ -37,7 +37,8 @@ module.exports = function (PIXI)
 
         var loadOptions = {
             crossOrigin: resource.crossOrigin,
-            loadType: Resource.LOAD_TYPE.IMAGE
+            loadType: Resource.LOAD_TYPE.IMAGE,
+            parentResource: resource
         };
 
         var urlForManifest = resource.url.replace(loader.baseUrl, "");

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "sinon-chai": "~2.7.0"
   },
   "dependencies": {
-    "resource-loader": "^1.6.6"
+    "resource-loader": "^2.0.4"
   }
 }


### PR DESCRIPTION
The new resource loader used by pixi 4 requires these changes, the parentResouce is necessary for it to work at all, the isJson is just a warning.