### PR TITLE
Test/pixi5

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,11 @@ function WaitForAll(count, allDone) {
 
 module.exports = function (PIXI)
 {
+    var PIXI_VERSION = Number(PIXI.VERSION.charAt(0));
+    if(PIXI_VERSION < 4) {
+        throw new Error("PIXI version needs to be >= v4.0.0");
+    }
+
     return function (resource, next)
     {
         // skip if no data, its not json, or it isn't a pixi-packer manifest
@@ -45,7 +50,7 @@ module.exports = function (PIXI)
         var route = pathWithoutFile(urlForManifest);
 
         var resolution = resource.data.resolution;
-        var versionResolutionFactor = Number(PIXI.VERSION.charAt(0)) >= 5 ? 1 : resolution;
+        var versionResolutionFactor = PIXI_VERSION >= 5 ? 1 : resolution;
 
         if (resource.data.spritesheets.length && loader.progress === 100) {
             // This is a temporary workaround until a solution for https://github.com/englercj/resource-loader/pull/32 is found
@@ -75,43 +80,26 @@ module.exports = function (PIXI)
                         sprite.dimension.h / versionResolutionFactor
                     );
 
-                    var crop;
-                    if (Number(PIXI.VERSION.charAt(0)) >= 4) {
-                        crop = new PIXI.Rectangle(
-                            0,
-                            0,
-                            sprite.dimension.w / resolution,
-                            sprite.dimension.h / resolution
-                        );
-                    } else {
-                        crop = frame.clone();
-                    }
+                    var crop = new PIXI.Rectangle(
+                        0,
+                        0,
+                        sprite.dimension.w / resolution,
+                        sprite.dimension.h / resolution
+                    );
 
                     var trim = crop;
 
                     //  Check to see if the sprite is trimmed
                     if (sprite.trim) {
-                        if (Number(PIXI.VERSION.charAt(0)) >= 4) {
-                            trim = new PIXI.Rectangle(
-                                sprite.trim.x / resolution,
-                                sprite.trim.y / resolution,
-                                sprite.trim.w / resolution,
-                                sprite.trim.h / resolution
-                            );
+                        trim = new PIXI.Rectangle(
+                            sprite.trim.x / resolution,
+                            sprite.trim.y / resolution,
+                            sprite.trim.w / resolution,
+                            sprite.trim.h / resolution
+                        );
 
-                            frame.width = sprite.trim.w / versionResolutionFactor;
-                            frame.height = sprite.trim.h / versionResolutionFactor;
-                        } else {
-                            trim = new PIXI.Rectangle(
-                                sprite.trim.x / resolution,
-                                sprite.trim.y / resolution,
-                                frame.width,
-                                frame.height
-                            );
-
-                            crop.width = sprite.trim.w / resolution;
-                            crop.height = sprite.trim.h / resolution;
-                        }
+                        frame.width = sprite.trim.w / versionResolutionFactor;
+                        frame.height = sprite.trim.h / versionResolutionFactor;
                     }
 
                     res.textures[sprite.name] = new PIXI.Texture(res.texture.baseTexture, frame, crop, trim, 0);

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ module.exports = function (PIXI)
         var route = pathWithoutFile(urlForManifest);
 
         var resolution = resource.data.resolution;
+        var versionResolutionFactor = Number(PIXI.VERSION.charAt(0)) >= 5 ? 1 : resolution;
 
         if (resource.data.spritesheets.length && loader.progress === 100) {
             // This is a temporary workaround until a solution for https://github.com/englercj/resource-loader/pull/32 is found
@@ -68,10 +69,10 @@ module.exports = function (PIXI)
                 res.textures = {};
                 spritesheet.sprites.forEach(function(sprite) {
                     var frame = new PIXI.Rectangle(
-                        sprite.position.x / resolution,
-                        sprite.position.y / resolution,
-                        sprite.dimension.w / resolution,
-                        sprite.dimension.h / resolution
+                        sprite.position.x / versionResolutionFactor,
+                        sprite.position.y / versionResolutionFactor,
+                        sprite.dimension.w / versionResolutionFactor,
+                        sprite.dimension.h / versionResolutionFactor
                     );
 
                     var crop;
@@ -86,7 +87,7 @@ module.exports = function (PIXI)
                         crop = frame.clone();
                     }
 
-                    var trim = null;
+                    var trim = crop;
 
                     //  Check to see if the sprite is trimmed
                     if (sprite.trim) {
@@ -98,8 +99,8 @@ module.exports = function (PIXI)
                                 sprite.trim.h / resolution
                             );
 
-                            frame.width = sprite.trim.w / resolution;
-                            frame.height = sprite.trim.h / resolution;
+                            frame.width = sprite.trim.w / versionResolutionFactor;
+                            frame.height = sprite.trim.h / versionResolutionFactor;
                         } else {
                             trim = new PIXI.Rectangle(
                                 sprite.trim.x / resolution,
@@ -113,7 +114,7 @@ module.exports = function (PIXI)
                         }
                     }
 
-                    res.textures[sprite.name] = new PIXI.Texture(res.texture.baseTexture, frame, crop, trim, false);
+                    res.textures[sprite.name] = new PIXI.Texture(res.texture.baseTexture, frame, crop, trim, 0);
 
                     // lets also add the frame to pixi's global cache for fromFrame and fromImage functions
                     PIXI.utils.TextureCache[sprite.name] = res.textures[sprite.name];


### PR DESCRIPTION
This is a demo PR with the goal of updating games to Pixiv5. We drop support for Pixi < 4 because no game uses it now.
Although the Textures Constructor options are the same for v4 and v5, probably by the way we import it, I had to do some changes to support retina images.